### PR TITLE
Treat summation values as a signed number

### DIFF
--- a/aioraven/data.py
+++ b/aioraven/data.py
@@ -100,13 +100,19 @@ def convert_float_formatted(
     digits_left: Optional[str] = None,
     suppress_leading_zero: Optional[str] = None,
 ) -> Optional[str]:
-    if raw is not None:
-        value = float(int(raw, 0))
+    value_int = convert_int(raw, sign_extend=True)
+    if value_int is not None:
+        value = float(value_int)
         if mult is not None:
             value *= int(mult, 0)
         if div is not None:
             value /= int(div, 0)
         whole, frac = str(value).split('.', 1)
+        if whole.startswith('-'):
+            sign = '-'
+            whole = whole[1:]
+        else:
+            sign = ''
         if digits_right is not None:
             places = int(digits_right, 0)
             difference = len(frac) - places
@@ -121,7 +127,7 @@ def convert_float_formatted(
                 whole = whole.lstrip('0')
                 if not whole:
                     whole = '0'
-        return f'{whole}.{frac}'
+        return f'{sign}{whole}.{frac}'
     return None
 
 
@@ -133,9 +139,16 @@ def convert_hex_to_bytes(raw: Optional[str]) -> Optional[bytes]:
     return None
 
 
-def convert_int(raw: Optional[str]) -> Optional[int]:
+def convert_int(
+    raw: Optional[str],
+    *,
+    sign_extend: bool = False,
+) -> Optional[int]:
     if raw is not None:
-        return int(raw, 0)
+        value = int(raw, 0)
+        if sign_extend:
+            value = (value & 0x7FFFFFFF) - (value & 0x80000000)
+        return value
     return None
 
 

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -348,6 +348,71 @@ async def test_get_instantaneous_demand():
 
 
 @pytest.mark.asyncio
+async def test_get_instantaneous_demand_negative():
+    """
+    Verify behavior of the ``get_instantaneous_demand`` command with a
+    negative value.
+    """
+    responses = {
+        b'<Command><Name>get_instantaneous_demand</Name></Command>':
+            b'<InstantaneousDemand>'
+            b'    <DeviceMacId>0x0123456789ABCDEF</DeviceMacId>'
+            b'    <MeterMacId>0xFEDCBA9876543210</MeterMacId>'
+            b'    <TimeStamp>0x29bd58a7</TimeStamp>'
+            b'    <Demand>0xFFFFFFF0</Demand>'
+            b'    <Multiplier>0x00000004</Multiplier>'
+            b'    <Divisor>0x00000002</Divisor>'
+            b'    <DigitsRight>0x02</DigitsRight>'
+            b'    <DigitsLeft>0x04</DigitsLeft>'
+            b'    <SuppressLeadingZero>Y</SuppressLeadingZero>'
+            b'</InstantaneousDemand>',
+    }
+
+    async with mock_device(responses) as (host, port):
+        async with RAVEnNetworkDevice(host, port) as dut:
+            actual = await dut.get_instantaneous_demand()
+
+    assert actual == InstantaneousDemand(
+        device_mac_id=bytes.fromhex('0123456789ABCDEF'),
+        meter_mac_id=bytes.fromhex('FEDCBA9876543210'),
+        time_stamp=datetime(
+            2022, 3, 11, 0, 47, 35, tzinfo=timezone.utc),
+        demand='-32.00')
+
+
+@pytest.mark.asyncio
+async def test_get_instantaneous_demand_negative_no_slz():
+    """
+    Verify behavior of the ``get_instantaneous_demand`` command with a
+    negative value and without SuppressLeadingZero.
+    """
+    responses = {
+        b'<Command><Name>get_instantaneous_demand</Name></Command>':
+            b'<InstantaneousDemand>'
+            b'    <DeviceMacId>0x0123456789ABCDEF</DeviceMacId>'
+            b'    <MeterMacId>0xFEDCBA9876543210</MeterMacId>'
+            b'    <TimeStamp>0x29bd58a7</TimeStamp>'
+            b'    <Demand>0xFFFFFFF0</Demand>'
+            b'    <Multiplier>0x00000004</Multiplier>'
+            b'    <Divisor>0x00000002</Divisor>'
+            b'    <DigitsRight>0x02</DigitsRight>'
+            b'    <DigitsLeft>0x04</DigitsLeft>'
+            b'</InstantaneousDemand>',
+    }
+
+    async with mock_device(responses) as (host, port):
+        async with RAVEnNetworkDevice(host, port) as dut:
+            actual = await dut.get_instantaneous_demand()
+
+    assert actual == InstantaneousDemand(
+        device_mac_id=bytes.fromhex('0123456789ABCDEF'),
+        meter_mac_id=bytes.fromhex('FEDCBA9876543210'),
+        time_stamp=datetime(
+            2022, 3, 11, 0, 47, 35, tzinfo=timezone.utc),
+        demand='-0032.00')
+
+
+@pytest.mark.asyncio
 async def test_get_instantaneous_demand_no_slz():
     """
     Verify behavior of the ``get_instantaneous_demand`` command without


### PR DESCRIPTION
This should fix a bug where large values are reported for InstantaneousDemand when pushing energy back to the grid.