### PR TITLE
Fix rounding error for values just under a whole number

### DIFF
--- a/aioraven/data.py
+++ b/aioraven/data.py
@@ -118,6 +118,9 @@ def convert_float_formatted(
             difference = len(frac) - places
             if difference > 0:
                 frac = str((int(frac) + 5 ** difference) // 10 ** difference)
+                if len(frac) > places:
+                    whole = str(int(whole) + 1)
+                    frac = frac[1:]
             elif difference < 0:
                 frac += '0' * (-difference)
         if digits_left is not None:

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -140,6 +140,41 @@ async def test_get_current_summation_delivered(meter):
 
 
 @pytest.mark.asyncio
+async def test_get_current_summation_delivered_rounding():
+    """
+    Verify rounding behavior of the ``get_current_summation_delivered``
+    command.
+    """
+    responses = {
+        b'<Command><Name>get_current_summation_delivered</Name></Command>':
+            b'<CurrentSummationDelivered>'
+            b'    <DeviceMacId>0x0123456789ABCDEF</DeviceMacId>'
+            b'    <MeterMacId>0xFEDCBA9876543210</MeterMacId>'
+            b'    <TimeStamp>0x29bd58a7</TimeStamp>'
+            b'    <SummationDelivered>0x00000C7B</SummationDelivered>'
+            b'    <SummationReceived>0x00000644</SummationReceived>'
+            b'    <Multiplier>0x00000002</Multiplier>'
+            b'    <Divisor>0x000000C8</Divisor>'
+            b'    <DigitsRight>0x01</DigitsRight>'
+            b'    <DigitsLeft>0x03</DigitsLeft>'
+            b'    <SuppressLeadingZero>N</SuppressLeadingZero>'
+            b'</CurrentSummationDelivered>',
+    }
+
+    async with mock_device(responses) as (host, port):
+        async with RAVEnNetworkDevice(host, port) as dut:
+            actual = await dut.get_current_summation_delivered()
+
+    assert actual == CurrentSummationDelivered(
+        device_mac_id=bytes.fromhex('0123456789ABCDEF'),
+        meter_mac_id=bytes.fromhex('FEDCBA9876543210'),
+        time_stamp=datetime(
+            2022, 3, 11, 0, 47, 35, tzinfo=timezone.utc),
+        summation_delivered='032.0',
+        summation_received='016.0')
+
+
+@pytest.mark.asyncio
 async def test_get_current_summation_delivered_no_received():
     """
     Verify behavior of the ``get_current_summation_delivered`` command without


### PR DESCRIPTION
The float formatting function is getting a little ridiculous. Maybe it could be optimized to avoid bugs like this.