### PR TITLE
Handle filler value for DateCode

### DIFF
--- a/aioraven/data.py
+++ b/aioraven/data.py
@@ -58,7 +58,7 @@ def convert_date(raw: Optional[str]) -> Optional[date]:
 
 
 def convert_date_code(raw: Optional[str]) -> Optional[Tuple[date, str]]:
-    if raw is not None:
+    if raw is not None and not all(ch == '\xff' for ch in raw):
         if len(raw) >= 9:
             date = convert_date(raw[:8])
             if date is not None:

--- a/aioraven/protocols.py
+++ b/aioraven/protocols.py
@@ -43,9 +43,10 @@ class RAVEnReaderProtocol(Protocol):
         self._closed = self._loop.create_future()
 
     def _reset(self) -> None:
-        self._parser = Et.XMLPullParser(events=('end',))
-        self._parser.feed(b'<?xml version="1.0" encoding="ASCII"?><root>')
         self._stash = b''
+        self._parser = Et.XMLPullParser(events=('end',))
+        self._parser.feed(
+            b'<?xml version="1.0" encoding="Windows-1252"?><root>')
 
     def _get_close_waiter(self, stream: Any) -> Future[None]:
         return self._closed


### PR DESCRIPTION
It appears that some EMU-2 devices will fill the date code with '\xff' characters in some scenarios. We've already seen some fields use 0xff to represent a sort of 'filler' value where there is no date to give. This scenario is a little bit different because the raw representation is 0xff where before we were seeing 0xff written out in ASCII characters, but given that the number of characters still matches documentation's expected value I think we can draw the same conclusion here.

There are a few components to this change:
1. Switch from plain ASCII to codepage 1252 extended ASCII. This is actually called out in the RAVEn protocol documentation.
2. Set the _stash attribute earlier in the _reset method to limit the fallout of any problems feeding the XML root tag to the parser.
3. Specifically handle an all-0xFF date code as 'None'.